### PR TITLE
typecast message param in __construct to prevent type error

### DIFF
--- a/system/classes/KO7/KO7/Exception.php
+++ b/system/classes/KO7/KO7/Exception.php
@@ -54,7 +54,7 @@ class KO7_KO7_Exception extends Exception {
         $message = I18n::get([$message, $variables]);
 
         // Pass the message and integer code to the parent
-        parent::__construct($message, (int) $code, $previous);
+        parent::__construct((string) $message, (int) $code, $previous);
 
         // Save the unmodified code
         // @link http://bugs.php.net/39615


### PR DESCRIPTION
# PR Details

typecast message param in __construct to prevent type error

### Description

Describe your changes in detail

### Related Issue

This project only accepts pull requests related to open issues

If suggesting a new feature or change, please discuss it in an issue first

If fixing a bug, there should be an issue describing it with steps to reproduce

Please link to the issue here

### How Has This Been Tested

Please describe in detail how you tested your changes and
see how your change affects other areas of the code, etc.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
